### PR TITLE
feat: deploy the site with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 
 env:
   global:
-    - GITHUB_REPO: opencobra/cobrapy
+    - GITHUB_REPO: Midnighter/dummy-site
     - HUGO_VER: 0.25.1
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,6 @@ deploy:
   repo: $GITHUB_REPO
   local_dir: public
   on:
-    branch: master
+    #    branch: master
+    all_branches: true
     repo: $GITHUB_REPO

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,22 +3,27 @@ sudo: false
 
 env:
   global:
-    - GITHUB_REPO: Midnighter/dummy-site
+    - GITHUB_REPO: opencobra/cobrapy
     - HUGO_VER: 0.25.1
+    - HUGO_DIR: public
 
 install:
   - wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VER}/hugo_${HUGO_VER}_Linux-64bit.tar.gz -O hugo.tar.gz
   - tar xvzf hugo.tar.gz
 
 script:
-  - ./hugo -d public
+  - ./hugo -d "${HUGO_DIR}"
 
 deploy:
   provider: pages
   skip_cleanup: true
   github_token: $GITHUB_TOKEN
   repo: $GITHUB_REPO
-  local_dir: public
+  local_dir: $HUGO_DIR
   on:
-    #    branch: master
-    all_branches: true
+    branch: master
+
+notifications:
+  email:
+    on_sucess: never
+    on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,12 @@ sudo: false
 env:
   global:
     - GITHUB_REPO: opencobra/cobrapy
-    - HUGO_VER: 0.29
+    - HUGO_VER: "0.29"
     - HUGO_DIR: public
+
+cache:
+  directories:
+  - /tmp/hugo_cache
 
 install:
   - wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VER}/hugo_${HUGO_VER}_Linux-64bit.tar.gz -O hugo.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: go
+sudo: false
+
+env:
+  global:
+    - GITHUB_REPO: opencobra/cobrapy
+    - HUGO_VER: 0.25.1
+
+install:
+  - wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VER}/hugo_${HUGO_VER}_Linux-64bit.tar.gz -O hugo.tar.gz
+  - tar xvzf hugo.tar.gz
+
+script:
+  - ./hugo -d public
+
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN
+  repo: $GITHUB_REPO
+  local_dir: public
+  on:
+    branch: master
+    repo: $GITHUB_REPO

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 env:
   global:
     - GITHUB_REPO: opencobra/cobrapy
-    - HUGO_VER: 0.25.1
+    - HUGO_VER: 0.29
     - HUGO_DIR: public
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,3 @@ deploy:
   on:
     #    branch: master
     all_branches: true
-    repo: $GITHUB_REPO


### PR DESCRIPTION
This introduces automatic deployment to `cobrapy/gh-pages` using Travis-CI on commits to `master`.