### PR TITLE
Add CNApy as package

### DIFF
--- a/content/packages/cnapy.md
+++ b/content/packages/cnapy.md
@@ -1,0 +1,10 @@
++++
+title = "CNApy"
+repo = "https://github.com/cnapy-org/CNApy"
+date = "2022-09-14T12:00:00"
+owner = "Sven Thiele, Philipp Schneider, Axel von Kamp, Pavlos Stephanos Bekiaris, Steffen Klamt"
+website = "https://cnapy-org.github.io/CNApy/"
+tags = ["strain-design", "visualization", "general-modeling", "cobra", "metabolic-model", "minimal-cut-sets", "models"]
++++
+
+CNApy is a graphical integrated environment for metabolic network analysis. With CNApy, it is possible to load, edit and create metabolic models together with interactive network maps. Many standard and advanced COBRA techniques (including, e.g., Flux Balance Analysis, Flux Variability Analysis and Minimal Cut Sets) are supported and all main results of these techniques can be directly visualized in the network maps. Furthermore, CNApy also provides a GUI for all major functions of the StrainDesign package.


### PR DESCRIPTION
Hello everyone!

With this PR, I'd like to add CNApy to your packages list. Many of its main functions (model loading and saving, FBA, FVA and more) make direct use of cobrapy. CNApy is developed at Steffen Klamt's lab in the Max Planck Institute Magdeburg, the same group that develops StrainDesign, which is already added to your packages list.

Kind regards
P.S.B.